### PR TITLE
Use nixpkgs-20.09

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 # If called without explicitly setting the 'pkgs' arg, a pinned nixpkgs version is used by default.
 # If you want to use your <nixpkgs> instead, set usePinnedPkgs to false (e.g., nix-build --arg usePinnedPkgs false ...)
 { usePinnedPkgs ? true
-, pkgs ? if usePinnedPkgs then import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/20.03.tar.gz") {}
+, pkgs ? if usePinnedPkgs then import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz") {}
                           else import <nixpkgs> {}
 , debug ? false
 }:

--- a/pkgs/batsched/batsched140.nix
+++ b/pkgs/batsched/batsched140.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "1d6f22h76x18gx7dgz47424why6q0hnhbrjm529fys7ha384s8nh";
   };
 
+  # Temporary hack. Meson is no longer able to pick up Boost automatically.
+  # https://github.com/NixOS/nixpkgs/issues/86131
+  BOOST_INCLUDEDIR = "${stdenv.lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${stdenv.lib.getLib boost}/lib";
+
   nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ boost gmp rapidjson intervalset loguru redox cppzmq zeromq ];
   mesonBuildType = if debug then "debug" else "release";

--- a/pkgs/batsched/master.nix
+++ b/pkgs/batsched/master.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     sed -iE "s/version: '.*',/version: '$version_name',/" meson.build
   '';
 
+  # Temporary hack. Meson is no longer able to pick up Boost automatically.
+  # https://github.com/NixOS/nixpkgs/issues/86131
+  BOOST_INCLUDEDIR = "${stdenv.lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${stdenv.lib.getLib boost}/lib";
+
   nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ boost gmp rapidjson intervalset loguru redox cppzmq zeromq ];
   mesonBuildType = if debug then "debug" else "release";

--- a/pkgs/batsim/batsim310.nix
+++ b/pkgs/batsim/batsim310.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0aa5b3bp7khazn7gyslczxydijigshxg5xf1284v31l28iq7mzvx";
   };
 
+  # Temporary hack. Meson is no longer able to pick up Boost automatically.
+  # https://github.com/NixOS/nixpkgs/issues/86131
+  BOOST_INCLUDEDIR = "${stdenv.lib.getDev boost}/include";
+  BOOST_LIBRARYDIR = "${stdenv.lib.getLib boost}/lib";
+
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/procset/default.nix
+++ b/pkgs/procset/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pkgs, fetchgit, python37Packages}:
+{ stdenv, pkgs, fetchgit, python3Packages}:
 
-python37Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   name = "procset-${version}";
   version = "v1.0";
 


### PR DESCRIPTION
Packages tested (package built, running `--version` worked as expected):
- batsim (all versions)
- batsched (all versions)
- pybatsim (all versions)
- rsg (all versions)
- simgrid (versions needed by other packages)

Problems fixed:
- Recent meson does not find boost ([nixpkgs issue 86131](https://github.com/NixOS/nixpkgs/issues/86131)). Not solved yet in nixpkgs, thus using a workaround.
- Default python is now 3.8 in nixpkgs. Caused pybatsim build to break because of a dependency using `python37Packages` instead of `python3Packages`. **Similar fixes should be done on other python packages**, I did not do them because I have no idea how to test these packages.