### PR TITLE
ci: broken packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ env:
 
 matrix:
   include:
-    - env: NIX_PATH=nixpkgs=channel:nixpkgs-unstable
-    - env: NIX_PATH=nixpkgs=channel:nixos-unstable
-    - env: NIX_PATH=nixpkgs=channel:nixos-20.03
+    # - env: NIX_PATH=nixpkgs=channel:nixpkgs-unstable
+    # - env: NIX_PATH=nixpkgs=channel:nixos-unstable
+    - env: NIX_PATH=nixpkgs=channel:nixos-20.09
 
 script:
  - nix-build ci.nix -A buildOutputs
@@ -35,5 +35,5 @@ script:
 
 after_success:
   - if [ -n "${CACHIX_CACHE}" ]; then nix-build ci.nix -A cacheOutputs | cachix push "${CACHIX_CACHE}"; fi
-  - if [[ NUR_REPO != "<YOUR_NUR_REPO_NAME_HERE>" && "cron" != "${TRAVIS_EVENT_TYPE}" && "false" = "${TRAVIS_PULL_REQUEST}" && "master" = "${TRAVIS_BRANCH}" ]]; then
+  - if [[ NUR_REPO != "kapack" && "cron" != "${TRAVIS_EVENT_TYPE}" && "false" = "${TRAVIS_PULL_REQUEST}" && "master" = "${TRAVIS_BRANCH}" ]]; then
       curl -XPOST "https://nur-update.herokuapp.com/update?repo=${NUR_REPO}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ install:
  - cachix use batsim
  - nix-channel --add "${NIX_CHANNEL}" nixpkgs
  - travis_retry nix-channel --update
+ - nix-channel --list
+ - echo ${NIX_PATH}
+ - ls -l /nix/var/nix/profiles/per-user/root/channels/nixpkgs
+
 
 script:
  - nix-build ci.nix -A buildOutputs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     #
     # For this to work, you also need to set the  CACHIX_SIGNING_KEY
     # in your repository settings in Travis.
-    # - CACHIX_CACHE=
+    - CACHIX_CACHE=nur-kapack
     # Set this to notify the global nur package registry that changes are
     # available.
     #
@@ -28,6 +28,7 @@ matrix:
     - env: NIX_PATH=nixpkgs=channel:nixos-20.09
 
 script:
+ - cachix use nur-kapack
  - nix-build ci.nix -A buildOutputs
  - nix eval -f default.nix 'lib'
  - nix eval -f default.nix 'modules'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,31 @@
-language: nix
+version: ~> 1.0
+import: nix-community/nix-travis-ci:nix.yml@main
 
 sudo: false
 
 env:
   global:
-    - CACHIX_CACHE=kapack
-    - NUR_REPO=https://github.com/oar-team/nur-kapack
+    # Set this to cache your build results in cachix for faster builds
+    # in travis and for everyone who uses your cache.
+    #
+    # Format: Your cachix cache host name without the ".cachix.org" suffix.
+    # Example: mycache (for mycache.cachix.org)
+    #
+    # For this to work, you also need to set the  CACHIX_SIGNING_KEY
+    # in your repository settings in Travis.
+    # - CACHIX_CACHE=
+    # Set this to notify the global nur package registry that changes are
+    # available.
+    #
+    # The repo name as used in
+    # https://github.com/nix-community/NUR/blob/master/repos.json
+    - NUR_REPO="kapack"
 
 matrix:
   include:
-#    - env: NIX_CHANNEL=https://nixos.org/channels/nixpkgs-unstable
-#    - env: NIX_CHANNEL=https://nixos.org/channels/nixos-unstable
-    - env: NIX_CHANNEL=https://nixos.org/channels/nixos-20.09
-
-install:
- - nix --version
- - echo "trusted-users = root travis" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon
- - if [ -n "${CACHIX_CACHE}" ]; then travis_retry nix-channel --update; fi
- - if [ -n "${CACHIX_CACHE}" ]; then nix-env -iA cachix -f https://cachix.org/api/v1/install; fi
- - if [ -n "${CACHIX_CACHE}" ]; then cachix use "${CACHIX_CACHE}"; fi
- - cachix use batsim
- - nix-channel --add "${NIX_CHANNEL}" nixpkgs
- - travis_retry nix-channel --update
- - nix-channel --list
- - echo ${NIX_PATH}
- - ls -l /nix/var/nix/profiles/per-user/root/channels/nixpkgs
-
+    - env: NIX_PATH=nixpkgs=channel:nixpkgs-unstable
+    - env: NIX_PATH=nixpkgs=channel:nixos-unstable
+    - env: NIX_PATH=nixpkgs=channel:nixos-20.03
 
 script:
  - nix-build ci.nix -A buildOutputs
@@ -35,6 +35,5 @@ script:
 
 after_success:
   - if [ -n "${CACHIX_CACHE}" ]; then nix-build ci.nix -A cacheOutputs | cachix push "${CACHIX_CACHE}"; fi
-  - if [ "false" = "${TRAVIS_PULL_REQUEST}" -a "master" = "${TRAVIS_BRANCH}" ]; then
+  - if [[ NUR_REPO != "<YOUR_NUR_REPO_NAME_HERE>" && "cron" != "${TRAVIS_EVENT_TYPE}" && "false" = "${TRAVIS_PULL_REQUEST}" && "master" = "${TRAVIS_BRANCH}" ]]; then
       curl -XPOST "https://nur-update.herokuapp.com/update?repo=${NUR_REPO}"; fi
-

--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@ rec {
   inherit pkgs;
 
   glibc-batsky = pkgs.glibc.overrideAttrs (attrs: {
+    meta.broken = true;
     patches = attrs.patches ++ [ ./pkgs/glibc-batsky/clock_gettime.patch
       ./pkgs/glibc-batsky/gettimeofday.patch ];
     postConfigure = ''

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,5 +1,5 @@
 {
-  overlay-dev = import ./overlay-dev.nix;
-  overlay = import ./overlay1.nix;
+ # overlay-dev = import ./overlay-dev.nix;
+ # overlay = import ./overlay1.nix;
 }
 

--- a/pkgs/oar/default.nix
+++ b/pkgs/oar/default.nix
@@ -46,6 +46,7 @@ python37Packages.buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/oar-team/oar3";
     description = "The OAR Resources and Tasks Management System";
     license = licenses.lgpl3;

--- a/pkgs/slurm-simulator/default.nix
+++ b/pkgs/slurm-simulator/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = http://www.schedmd.com/;
     description = "Simple Linux Utility for Resource Management";
     platforms = platforms.linux;


### PR DESCRIPTION
The ci was broken for a long time, this pull request fixes the issues (proof: https://www.travis-ci.com/github/adfaure/nur-kapack/builds/216121167)

This is important because, to update `nur-kapack` on the main [NUR](https://github.com/nix-community/NUR) repository (and update the [json](https://github.com/nix-community/NUR/blob/master/repos.json.lock)) one need to perform an http request on the NUR application.
When we create a new nur repository from the template, this request is made at the end of the CI, if the build was succesful.

## What changed

- [980c4e61](https://github.com/adfaure/nur-kapack/comm/769d2a01fcdf3bde787e9bf5b2705e8ac923b775) : I installed cachix, otherwise, the job's time exceeds the travis's walltime of 1 hour.
- [769d2a01](https://github.com/adfaure/nur-kapack/comm/769d2a01fcdf3bde787e9bf5b2705e8ac923b775) : The default template comes with a `.travis.yml` script. However, ours was a bit outdated so I got the new one from https://github.com/nix-community/nur-packages-template.
- Before [8e94f98](https://github.com/adfaure/nur-kapack/commit/8e94f98364834888c991ae634bd0513577030356) some packages were broken: `oar`, `slurm-simulator` and `glibc-batsky`.

## Notes

Without cachix, the build time of the ci job is too long.
You can push everything on cachix, and then run the ci.

```bash
NIX_PATH=nixpkgs=channel:nixos-20.09 nix-build ci.nix -A buildOutputs | cachix push nur-kapack
```