### PR TITLE
Flake for the NUR

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,39 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "haskellPackagesNUR": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "narHash": "sha256-0Rix96NOKD2pEJdssboJkEm9vf9F/gFGvo//1LCFziI=",
+        "path": "./pkgs/haskellPackages",
+        "type": "path"
+      },
+      "original": {
+        "path": "./pkgs/haskellPackages",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1635781173,
@@ -18,6 +52,8 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
+        "haskellPackagesNUR": "haskellPackagesNUR",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,40 @@
 {
   description = " My personal NUR repository";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  outputs = { self, nixpkgs }: let
-    systems = [
-      "x86_64-linux"
-      "i686-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "armv6l-linux"
-      "armv7l-linux"
-    ];
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-  in {
-    packages = forAllSystems (system: import ./default.nix {
-      pkgs = import nixpkgs { inherit system; };
-    });
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    haskellPackagesNUR = {
+      url = "path:./pkgs/haskellPackages";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
+
+  outputs = { self, nixpkgs, flake-utils, haskellPackagesNUR }:
+    let
+      systems = [
+        "x86_64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+      ];
+      inherit (flake-utils.lib) eachSystem filterPackages;
+
+    in eachSystem systems (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowBroken = true; # FIXME
+        };
+      in {
+        packages = (filterPackages system (import ./nur.nix { inherit pkgs; })
+          // haskellPackagesNUR.packages.${system});
+      }) // {
+        nixosModules =
+          builtins.mapAttrs (name: path: import path) (import ./modules);
+        overlay = import ./overlay.nix;
+      };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,7 +5,7 @@
   rs-munge = ./services/bs-munge.nix;
   oar = ./services/oar.nix;
   cigri = ./services/cigri.nix;
-  colmet = ./services/colmet.nix;
+  # colmet = ./services/colmet.nix;
   my-startup = ./services/my-startup.nix;
   phpfpm0 = ./services/phpfpm0.nix;
 }

--- a/nur.nix
+++ b/nur.nix
@@ -1,10 +1,8 @@
 # If called without explicitly setting the 'pkgs' arg, a pinned nixpkgs version is used by default.
 { pkgs ? import (fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz";
-    sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
-  }) {}
-, debug ? false
-}:
+  url = "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz";
+  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+}) { }, debug ? false }:
 
 rec {
   # The `lib`, `modules`, and `overlay` names are special
@@ -15,8 +13,10 @@ rec {
 
   glibc-batsky = pkgs.glibc.overrideAttrs (attrs: {
     meta.broken = true;
-    patches = attrs.patches ++ [ ./pkgs/glibc-batsky/clock_gettime.patch
-      ./pkgs/glibc-batsky/gettimeofday.patch ];
+    patches = attrs.patches ++ [
+      ./pkgs/glibc-batsky/clock_gettime.patch
+      ./pkgs/glibc-batsky/gettimeofday.patch
+    ];
     postConfigure = ''
       export NIX_CFLAGS_LINK=
       export NIX_LDFLAGS_BEFORE=
@@ -43,19 +43,34 @@ rec {
 
   haskellPackages = import ./pkgs/haskellPackages { inherit pkgs; };
 
-  batsched-130 = pkgs.callPackage ./pkgs/batsched/batsched130.nix { inherit intervalset loguru redox debug; };
-  batsched-140 = pkgs.callPackage ./pkgs/batsched/batsched140.nix { inherit intervalset loguru redox debug; };
+  batsched-130 = pkgs.callPackage ./pkgs/batsched/batsched130.nix {
+    inherit intervalset loguru redox debug;
+  };
+  batsched-140 = pkgs.callPackage ./pkgs/batsched/batsched140.nix {
+    inherit intervalset loguru redox debug;
+  };
   batsched = batsched-140;
 
   batexpe = pkgs.callPackage ./pkgs/batexpe { };
 
-  batprotocol-cpp = pkgs.callPackage ./pkgs/batprotocol/cpp.nix { inherit flatbuffers debug; };
+  batprotocol-cpp =
+    pkgs.callPackage ./pkgs/batprotocol/cpp.nix { inherit flatbuffers debug; };
 
-  batsim-310 = pkgs.callPackage ./pkgs/batsim/batsim310.nix { inherit intervalset redox debug; simgrid = simgrid-324; };
-  batsim-400 = pkgs.callPackage ./pkgs/batsim/batsim400.nix { inherit intervalset redox debug; simgrid = simgrid-325light; };
-  batsim-410 = pkgs.callPackage ./pkgs/batsim/batsim410.nix { inherit intervalset redox debug; simgrid = simgrid-329light; };
+  batsim-310 = pkgs.callPackage ./pkgs/batsim/batsim310.nix {
+    inherit intervalset redox debug;
+    simgrid = simgrid-324;
+  };
+  batsim-400 = pkgs.callPackage ./pkgs/batsim/batsim400.nix {
+    inherit intervalset redox debug;
+    simgrid = simgrid-325light;
+  };
+  batsim-410 = pkgs.callPackage ./pkgs/batsim/batsim410.nix {
+    inherit intervalset redox debug;
+    simgrid = simgrid-329light;
+  };
   batsim = batsim-410;
-  batsim-docker = pkgs.callPackage ./pkgs/batsim/batsim-docker.nix { inherit batsim; };
+  batsim-docker =
+    pkgs.callPackage ./pkgs/batsim/batsim-docker.nix { inherit batsim; };
 
   batsky = pkgs.callPackage ./pkgs/batsky { };
 
@@ -73,7 +88,7 @@ rec {
 
   melissa = pkgs.callPackage ./pkgs/melissa { };
 
-  go-swagger  = pkgs.callPackage ./pkgs/go-swagger { };
+  go-swagger = pkgs.callPackage ./pkgs/go-swagger { };
 
   gcovr = pkgs.callPackage ./pkgs/gcovr/csv.nix { };
 
@@ -87,7 +102,8 @@ rec {
 
   oxidisched = pkgs.callPackage ./pkgs/oxidisched { };
 
-  pybatsim-320 = pkgs.callPackage ./pkgs/pybatsim/pybatsim320.nix { inherit procset; };
+  pybatsim-320 =
+    pkgs.callPackage ./pkgs/pybatsim/pybatsim320.nix { inherit procset; };
   pybatsim = pybatsim-320;
 
   redox = pkgs.callPackage ./pkgs/redox { };
@@ -95,9 +111,8 @@ rec {
   remote_pdb = pkgs.callPackage ./pkgs/remote-pdb { };
 
   rt-tests = pkgs.callPackage ./pkgs/rt-tests { };
-  
+
   cigri = pkgs.callPackage ./pkgs/cigri { };
-	
 
   oar = pkgs.callPackage ./pkgs/oar { inherit procset pybatsim remote_pdb; };
 
@@ -105,34 +120,62 @@ rec {
 
   oar3 = oar;
 
-  rsg-030 = pkgs.callPackage ./pkgs/remote-simgrid/rsg030.nix { inherit debug ; simgrid = simgrid-326; };
+  rsg-030 = pkgs.callPackage ./pkgs/remote-simgrid/rsg030.nix {
+    inherit debug;
+    simgrid = simgrid-326;
+  };
   rsg = rsg-030;
 
-  simgrid-324 = pkgs.callPackage ./pkgs/simgrid/simgrid324.nix { inherit debug; };
-  simgrid-325 = pkgs.callPackage ./pkgs/simgrid/simgrid325.nix { inherit debug; };
-  simgrid-326 = pkgs.callPackage ./pkgs/simgrid/simgrid326.nix { inherit debug; };
-  simgrid-327 = pkgs.callPackage ./pkgs/simgrid/simgrid327.nix { inherit debug; };
-  simgrid-328 = pkgs.callPackage ./pkgs/simgrid/simgrid328.nix { inherit debug; };
-  simgrid-329 = pkgs.callPackage ./pkgs/simgrid/simgrid329.nix { inherit debug; };
-  simgrid-325light = simgrid-325.override { minimalBindings = true; withoutBin = true; };
-  simgrid-326light = simgrid-326.override { minimalBindings = true; withoutBin = true; };
-  simgrid-327light = simgrid-327.override { minimalBindings = true; withoutBin = true; };
-  simgrid-328light = simgrid-328.override { minimalBindings = true; withoutBin = true; };
-  simgrid-329light = simgrid-329.override { minimalBindings = true; withoutBin = true; };
+  simgrid-324 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid324.nix { inherit debug; };
+  simgrid-325 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid325.nix { inherit debug; };
+  simgrid-326 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid326.nix { inherit debug; };
+  simgrid-327 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid327.nix { inherit debug; };
+  simgrid-328 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid328.nix { inherit debug; };
+  simgrid-329 =
+    pkgs.callPackage ./pkgs/simgrid/simgrid329.nix { inherit debug; };
+  simgrid-325light = simgrid-325.override {
+    minimalBindings = true;
+    withoutBin = true;
+  };
+  simgrid-326light = simgrid-326.override {
+    minimalBindings = true;
+    withoutBin = true;
+  };
+  simgrid-327light = simgrid-327.override {
+    minimalBindings = true;
+    withoutBin = true;
+  };
+  simgrid-328light = simgrid-328.override {
+    minimalBindings = true;
+    withoutBin = true;
+  };
+  simgrid-329light = simgrid-329.override {
+    minimalBindings = true;
+    withoutBin = true;
+  };
   simgrid = simgrid-329;
   simgrid-light = simgrid-329light;
 
   # Setting needed for nixos-19.03 and nixos-19.09
-  slurm-bsc-simulator =
-    if pkgs ? libmysql
-    then pkgs.callPackage ./pkgs/slurm-simulator { libmysqlclient = pkgs.libmysql; }
-    else pkgs.callPackage ./pkgs/slurm-simulator { };
+  slurm-bsc-simulator = if pkgs ? libmysql then
+    pkgs.callPackage ./pkgs/slurm-simulator { libmysqlclient = pkgs.libmysql; }
+  else
+    pkgs.callPackage ./pkgs/slurm-simulator { };
   slurm-bsc-simulator-v17 = slurm-bsc-simulator;
 
   #slurm-bsc-simulator-v14 = slurm-bsc-simulator.override { version="14"; };
 
   slurm-multiple-slurmd = pkgs.slurm.overrideAttrs (oldAttrs: {
-    configureFlags = oldAttrs.configureFlags ++ ["--enable-multiple-slurmd" "--enable-silent-rules"];});
+    configureFlags = oldAttrs.configureFlags
+      ++ [ "--enable-multiple-slurmd" "--enable-silent-rules" ];
+    meta.platforms = pkgs.lib.lists.intersectLists pkgs.rdma-core.meta.platforms
+      pkgs.ghc.meta.platforms;
+  });
 
   slurm-front-end = pkgs.slurm.overrideAttrs (oldAttrs: {
     configureFlags = [
@@ -142,6 +185,8 @@ rec {
       "--sysconfdir=/etc/slurm"
       "--enable-silent-rules"
     ];
+    meta.platforms = pkgs.lib.lists.intersectLists pkgs.rdma-core.meta.platforms
+      pkgs.ghc.meta.platforms;
   });
 
   # bs-slurm = pkgs.replaceDependency {

--- a/overlay.nix
+++ b/overlay.nix
@@ -2,13 +2,14 @@
 # case where you don't want to add the whole NUR namespace to your
 # configuration.
 
-self: super:
+# self: super:
+final: prev:
 
 let
 
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   nameValuePair = n: v: { name = n; value = v; };
-  nurAttrs = import ./default.nix { pkgs = super; };
+  nurAttrs = import ./default.nix { pkgs = prev; };
 
 in
 

--- a/pkgs/batexpe/default.nix
+++ b/pkgs/batexpe/default.nix
@@ -37,6 +37,6 @@ buildGoPackage rec {
     license = licenses.lgpl3;
     broken = false;
     maintainers = with maintainers; [ mickours ];
-    platforms = platforms.all;
+    platforms = iproute.meta.platforms;
   };
 }

--- a/pkgs/batsky/default.nix
+++ b/pkgs/batsky/default.nix
@@ -31,7 +31,7 @@ python37Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "";
     homepage    = https://github.com/oar-team/batsky;
-    platforms   = platforms.unix;
+    platforms   = python37Packages.pyinotify.meta.platforms;
     licence     = licenses.gpl2;
     longDescription = ''
     '';

--- a/pkgs/colmet/default.nix
+++ b/pkgs/colmet/default.nix
@@ -34,7 +34,7 @@ python37Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Collecting metrics about process running in cpuset and in a distributed environnement";
     homepage    = https://github.com/oar-team/colmet;
-    platforms   = platforms.all;
+    platforms   = libpowercap.meta.platforms;
     licence     = licenses.gpl2;
     longDescription = ''
     '';

--- a/pkgs/evalys/default.nix
+++ b/pkgs/evalys/default.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonPackage rec {
   meta = with lib; {
     description = "Infrastructure Performance Evaluation Toolkit Edit";
     homepage    = https://github.com/oar-team/evalys;
-    platforms   = platforms.all;
+    platforms   = python3Packages.debugpy.meta.platforms; # TODO: be more precise if possible
     license = licenses.bsd3;
     longDescription = ''
         Evalys is a data analytics library made to load, compute,

--- a/pkgs/go-swagger/default.nix
+++ b/pkgs/go-swagger/default.nix
@@ -17,9 +17,8 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
   
-  # buildFlagsArray = ''
   ldflags = ''
-    -ldflags=-X github.com/go-swagger/go-swagger/cmd/swagger/commands/version.Version=${version}
+    -X github.com/go-swagger/go-swagger/cmd/swagger/commands/version.Version=${version}
   '';
 
   meta = with lib; {

--- a/pkgs/go-swagger/default.nix
+++ b/pkgs/go-swagger/default.nix
@@ -17,7 +17,8 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
   
-  buildFlagsArray = ''
+  # buildFlagsArray = ''
+  ldflags = ''
     -ldflags=-X github.com/go-swagger/go-swagger/cmd/swagger/commands/version.Version=${version}
   '';
 

--- a/pkgs/haskellPackages/arion-compose.nix
+++ b/pkgs/haskellPackages/arion-compose.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, aeson, aeson-pretty, async, base, bytestring
-, directory, fetchgit, hspec, lens, lens-aeson
+, directory, fetchgit, ghc, hspec, lens, lens-aeson
 , optparse-applicative, process, protolude, QuickCheck, stdenv
 , temporary, text, unix
 }:
@@ -31,4 +31,6 @@ mkDerivation {
   homepage = "https://github.com/hercules-ci/arion#readme";
   description = "Run docker-compose with help from Nix/NixOS";
   license = lib.licenses.asl20;
+  # Somehow the mkDerivation for Haskell does not allow a list of platforms...
+  platforms = ghc.meta.platforms;
 }

--- a/pkgs/haskellPackages/flake.nix
+++ b/pkgs/haskellPackages/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Flake Haskell Packages NUR";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }: 
+    let
+      systems = [
+        "x86_64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+      ];
+      inherit (flake-utils.lib) eachSystem filterPackages;
+    in eachSystem systems (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        packages = (filterPackages system (import ./default.nix { inherit pkgs; }));
+      });
+}

--- a/pkgs/kube-batch/default.nix
+++ b/pkgs/kube-batch/default.nix
@@ -15,9 +15,8 @@ buildGoPackage rec {
 
   subPackages = [ "cmd/kube-batch" ];
 
-  # buildFlagsArray = ''
   ldflags = ''
-    -ldflags=-X github.com/kubernetes-sigs/kube-batch/pkg/version.Version=${version}
+    -X github.com/kubernetes-sigs/kube-batch/pkg/version.Version=${version}
   '';
 
   meta = with lib; {

--- a/pkgs/kube-batch/default.nix
+++ b/pkgs/kube-batch/default.nix
@@ -15,7 +15,8 @@ buildGoPackage rec {
 
   subPackages = [ "cmd/kube-batch" ];
 
-  buildFlagsArray = ''
+  # buildFlagsArray = ''
+  ldflags = ''
     -ldflags=-X github.com/kubernetes-sigs/kube-batch/pkg/version.Version=${version}
   '';
 

--- a/pkgs/melissa/default.nix
+++ b/pkgs/melissa/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "https://melissa-sa.github.io/";
     description = "Melissa is a file avoiding, adaptive, fault tolerant and elastic framework, to run large scale sensitivity analysis on supercomputers";
     license = licenses.bsd3;
-    platforms = with platforms; [ x86_64 aarch64 i686 ];
+    platforms = with platforms; x86_64 ++ aarch64 ++ i686;
   };
 }

--- a/pkgs/melissa/default.nix
+++ b/pkgs/melissa/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "https://melissa-sa.github.io/";
     description = "Melissa is a file avoiding, adaptive, fault tolerant and elastic framework, to run large scale sensitivity analysis on supercomputers";
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = with platforms; [ x86_64 aarch64 i686 ];
   };
 }

--- a/pkgs/rt-tests/default.nix
+++ b/pkgs/rt-tests/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/rt-tests;
     license = licenses.gpl2Plus;
-    platforms = platforms.all;
+    platforms = numactl.meta.platforms;
     broken = false;
   };
 }


### PR DESCRIPTION
Those commits gather some "flakifications":

1. fix the flake
   this required to filter out the broken packages.

2. some packages did not have the correct platforms
   and thus failing the `nix flake check`.
   In order to determine the correct platforms, we ran
   `nix flake check --show-trace` and it tells us which
   dependency of the package cannot be built on the desired
   system.
   We then set the platforms of our package equal to the platforms
   of the limiting dependency.
   In the case that there are several dependencies with platforms
   limitations, we take the intersections between the platforms.

3. A flakes wants a set of derivations as output.
   However, the nur has some haskellPackages represented as a set.
   We cannot simply put the set in the flake output (or if we can
   I don't know how...).
   I thus created a flake for this haskellPackages and imported it
   inside the main NUR flake.
   I'm not 100percent certain this is the best choice tho...

(et un coup de `nixfmt` par bonne mesure)