### PR TITLE
Add IS benchmark in NPB

### DIFF
--- a/pkgs/npb/default.nix
+++ b/pkgs/npb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, openmpi, automake, gfortran, bc, benchs ? "ep cg mg ft bt sp lu", classes ? "A B C D E F", buildOmp ? true }:
+{ stdenv, lib, fetchurl, openmpi, automake, gfortran, bc, benchs ? "ep cg mg ft bt sp lu is", classes ? "A B C D E F", buildOmp ? true }:
 
 stdenv.mkDerivation rec {
   name = "NPB-${version}";


### PR DESCRIPTION
Adding IS benchmark: 	[Integer Sort](https://en.wikipedia.org/wiki/Integer_sorting) 	Sort small integers using the [bucket sort](https://en.wikipedia.org/wiki/Bucket_sort)[[5]](https://en.wikipedia.org/wiki/NAS_Parallel_Benchmarks#cite_note-npb2.2-5)