### PR TITLE
Fix the last standing references to pkgs.nur.repos.kapack in cigri and oar modules

### DIFF
--- a/modules/services/cigri-conf.nix
+++ b/modules/services/cigri-conf.nix
@@ -69,7 +69,7 @@ REST_CLIENT_KEY_FILE="/etc/cigri/ssl/cigri.key"
 # Minimum cycle duration
 # The runner sleeps this time of seconds if necessary to prevent
 # from looping too fast and let the time to clusters for jobs digestion
-RUNNER_MIN_CYCLE_DURATION = "${cfg.server.cycleDuration}"
+RUNNER_MIN_CYCLE_DURATION = "${toString cfg.server.cycleDuration}"
 # Default initial number of jobs to submit
 # The runner submits several jobs at a time using oar array jobs.
 # This number specifies the initial number of jobs to submit. Then,

--- a/modules/services/cigri-conf.nix
+++ b/modules/services/cigri-conf.nix
@@ -69,7 +69,7 @@ REST_CLIENT_KEY_FILE="/etc/cigri/ssl/cigri.key"
 # Minimum cycle duration
 # The runner sleeps this time of seconds if necessary to prevent
 # from looping too fast and let the time to clusters for jobs digestion
-RUNNER_MIN_CYCLE_DURATION = "15"
+RUNNER_MIN_CYCLE_DURATION = "${cfg.server.cycleDuration}"
 # Default initial number of jobs to submit
 # The runner submits several jobs at a time using oar array jobs.
 # This number specifies the initial number of jobs to submit. Then,

--- a/modules/services/cigri.nix
+++ b/modules/services/cigri.nix
@@ -150,7 +150,7 @@ in
     environment.etc."cigri/cigri-base.conf" = { mode = "0600"; source = cigriBaseConf; };
     environment.etc."cigri/api-clients.conf" = mkIf cfg.client.enable {source = cigriApiClientsConf; };
 
-    environment.systemPackages =  [ pkgs.nur.repos.kapack.cigri ];
+    environment.systemPackages =  [ cfg.package ];
     # cigri user declaration
     users.users.cigri = mkIf cfg.server.enable {
       description = "CiGri user";

--- a/modules/services/cigri.nix
+++ b/modules/services/cigri.nix
@@ -128,6 +128,14 @@ in
         web = {
           enable = mkEnableOption "Web server to serve rest-api";
         };
+
+        cycleDuration = mkOption {
+          type = types.int;
+          default = 15;
+          description = ''
+            Sampling period of CiGri
+          '';
+        };
       
       };
       

--- a/modules/services/oar.nix
+++ b/modules/services/oar.nix
@@ -109,7 +109,7 @@ let
       for (( i=0; i<''${#a[@]}; i++ ))
       do
         echo generate ''${a[i]}
-        gen_oardo ${pkgs.nur.repos.kapack.oar}/bin .''${a[i]} ''${a[i]}
+        gen_oardo ${cfg.package}/bin .''${a[i]} ''${a[i]}
       done
 
       # generate binary wrappers fo oarsh 
@@ -329,7 +329,7 @@ in
         oarTools
         taktuk
         xorg.xauth
-        nur.repos.kapack.oar
+        cfg.package
       ];
 
       # manage setuid for oardodo and oarcli
@@ -490,7 +490,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" "oar-user-init.service" "oar-conf-init.service" "oar-node.service" ];
         serviceConfig.Type = "oneshot";
-        path = [ pkgs.hostname ];
+        path = [ pkgs.hostname cfg.package ];
         script = concatStringsSep "\n" [
           (optionalString cfg.node.register.add
             "/run/wrappers/bin/oarnodesetting -a -s Alive")
@@ -681,7 +681,7 @@ in
             chdir = pkgs.writeTextDir "oarapi.py" ''
               from oar.rest_api.app import wsgi_app as application
             '';
-            pythonPackages = self: with self; [ pkgs.nur.repos.kapack.oar ]; #TODO : test is needed
+            pythonPackages = self: with self; [ cfg.package ]; #TODO : test is needed
           };
         };
       };
@@ -724,7 +724,7 @@ in
               app = create_app(config=config, root_path="/api/")
             '';
             app_env =
-              pkgs.python3.withPackages (ps: [ pkgs.nur.repos.kapack.oar ]);
+              pkgs.python3.withPackages (ps: [ cfg.package ]);
           in
           pkgs.lib.strings.toJSON {
             listeners."*:8080" = {


### PR DESCRIPTION
There were still some references to `pkgs.nur.repos.kapack.{cigri,oar}` in their respective modules.

Now every reference to the package is passed by `cfg.package`, so that we can easily change the package with `services.oar.package` and `services.cigri.package`.