### PR TITLE
fix alumet version for url: 8.3.0 -> v8.3.0

### DIFF
--- a/pkgs/alumet/default.nix
+++ b/pkgs/alumet/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
      owner = "alumet-dev";
      repo = pname;
-     rev = version;
+     rev = "v${version}";
      hash = "sha256-du9LPNOJp6fFEmddhj2ye4Vy+gzPy8eq2CrGdrV9Ao8=";
   };
 


### PR DESCRIPTION
The sources of alumet could not be found because the tags are the version numbers prefixed by "v".